### PR TITLE
feat: SearchAddon for find in terminal buffer

### DIFF
--- a/lib/addons/search.test.ts
+++ b/lib/addons/search.test.ts
@@ -1,0 +1,210 @@
+/**
+ * SearchAddon unit tests
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { SearchAddon } from './search';
+
+// Mock terminal with buffer lines
+function createMockTerminal(lines: string[]) {
+  const bufferLines = lines.map((text) => ({
+    length: text.length,
+    isWrapped: false,
+    getCell: () => undefined,
+    translateToString: () => text,
+  }));
+
+  return {
+    cols: 80,
+    rows: lines.length,
+    element: undefined,
+    textarea: undefined,
+    buffer: {
+      active: {
+        type: 'normal' as const,
+        cursorX: 0,
+        cursorY: 0,
+        viewportY: 0,
+        baseY: 0,
+        length: lines.length,
+        getLine: (y: number) => (y >= 0 && y < bufferLines.length ? bufferLines[y] : undefined),
+        getNullCell: () => ({ getChars: () => '', getCode: () => 0, getWidth: () => 1 }),
+      },
+      normal: {} as any,
+      alternate: {} as any,
+      onBufferChange: (() => ({ dispose: () => {} })) as any,
+    },
+    options: {},
+    select: () => {},
+    clearSelection: () => {},
+    scrollToLine: () => {},
+    scrollToBottom: () => {},
+  };
+}
+
+describe('SearchAddon', () => {
+  test('findNext returns false for empty search', () => {
+    const term = createMockTerminal(['hello world']);
+    const search = new SearchAddon();
+    search.activate(term as any);
+
+    expect(search.findNext('')).toBe(false);
+  });
+
+  test('findNext finds a match', () => {
+    const term = createMockTerminal(['hello world', 'foo bar']);
+    const search = new SearchAddon();
+    search.activate(term as any);
+
+    expect(search.findNext('hello')).toBe(true);
+    expect(search.matchCount).toBe(1);
+    expect(search.currentMatch).toBe(0);
+  });
+
+  test('findNext finds multiple matches', () => {
+    const term = createMockTerminal(['abc abc', 'abc xyz']);
+    const search = new SearchAddon();
+    search.activate(term as any);
+
+    expect(search.findNext('abc')).toBe(true);
+    expect(search.matchCount).toBe(3);
+    expect(search.currentMatch).toBe(0);
+
+    expect(search.findNext('abc')).toBe(true);
+    expect(search.currentMatch).toBe(1);
+
+    expect(search.findNext('abc')).toBe(true);
+    expect(search.currentMatch).toBe(2);
+
+    // Wraps around
+    expect(search.findNext('abc')).toBe(true);
+    expect(search.currentMatch).toBe(0);
+  });
+
+  test('findPrevious goes backwards', () => {
+    const term = createMockTerminal(['abc def', 'abc ghi']);
+    const search = new SearchAddon();
+    search.activate(term as any);
+
+    // First call starts from end
+    expect(search.findPrevious('abc')).toBe(true);
+    expect(search.currentMatch).toBe(1); // last match
+
+    expect(search.findPrevious('abc')).toBe(true);
+    expect(search.currentMatch).toBe(0);
+
+    // Wraps around
+    expect(search.findPrevious('abc')).toBe(true);
+    expect(search.currentMatch).toBe(1);
+  });
+
+  test('case-insensitive search by default', () => {
+    const term = createMockTerminal(['Hello HELLO hello']);
+    const search = new SearchAddon();
+    search.activate(term as any);
+
+    expect(search.findNext('hello')).toBe(true);
+    expect(search.matchCount).toBe(3);
+  });
+
+  test('case-sensitive search when enabled', () => {
+    const term = createMockTerminal(['Hello HELLO hello']);
+    const search = new SearchAddon();
+    search.activate(term as any);
+
+    expect(search.findNext('Hello', { caseSensitive: true })).toBe(true);
+    expect(search.matchCount).toBe(1);
+  });
+
+  test('regex search', () => {
+    const term = createMockTerminal(['abc 123 def 456']);
+    const search = new SearchAddon();
+    search.activate(term as any);
+
+    expect(search.findNext('\\d+', { regex: true })).toBe(true);
+    expect(search.matchCount).toBe(2);
+  });
+
+  test('whole word search', () => {
+    const term = createMockTerminal(['cat catch concatenate']);
+    const search = new SearchAddon();
+    search.activate(term as any);
+
+    expect(search.findNext('cat', { wholeWord: true })).toBe(true);
+    expect(search.matchCount).toBe(1);
+  });
+
+  test('no match returns false', () => {
+    const term = createMockTerminal(['hello world']);
+    const search = new SearchAddon();
+    search.activate(term as any);
+
+    expect(search.findNext('xyz')).toBe(false);
+    expect(search.matchCount).toBe(0);
+  });
+
+  test('clearDecorations resets state', () => {
+    const term = createMockTerminal(['hello world']);
+    const search = new SearchAddon();
+    search.activate(term as any);
+
+    search.findNext('hello');
+    expect(search.matchCount).toBe(1);
+
+    search.clearDecorations();
+    expect(search.matchCount).toBe(0);
+    expect(search.currentMatch).toBe(-1);
+  });
+
+  test('select is called with match coordinates', () => {
+    let selectedCol = -1;
+    let selectedRow = -1;
+    let selectedLen = -1;
+
+    const term = createMockTerminal(['foo hello bar']);
+    term.select = (col: number, row: number, length: number) => {
+      selectedCol = col;
+      selectedRow = row;
+      selectedLen = length;
+    };
+
+    const search = new SearchAddon();
+    search.activate(term as any);
+
+    search.findNext('hello');
+    expect(selectedCol).toBe(4);
+    expect(selectedRow).toBe(0);
+    expect(selectedLen).toBe(5);
+  });
+
+  test('search across multiple lines', () => {
+    const term = createMockTerminal([
+      'line 1: first match here',
+      'line 2: nothing',
+      'line 3: second match here',
+    ]);
+    const search = new SearchAddon();
+    search.activate(term as any);
+
+    expect(search.findNext('match')).toBe(true);
+    expect(search.matchCount).toBe(2);
+  });
+
+  test('invalid regex does not crash', () => {
+    const term = createMockTerminal(['hello world']);
+    const search = new SearchAddon();
+    search.activate(term as any);
+
+    expect(search.findNext('[invalid', { regex: true })).toBe(false);
+  });
+
+  test('dispose clears state', () => {
+    const term = createMockTerminal(['hello']);
+    const search = new SearchAddon();
+    search.activate(term as any);
+    search.findNext('hello');
+
+    search.dispose();
+    expect(search.matchCount).toBe(0);
+  });
+});

--- a/lib/addons/search.ts
+++ b/lib/addons/search.ts
@@ -1,0 +1,224 @@
+/**
+ * SearchAddon - Find text in the terminal buffer
+ *
+ * Provides find-next / find-previous functionality across the terminal
+ * buffer (including scrollback). Highlights matches via selection.
+ *
+ * Usage:
+ * ```typescript
+ * const searchAddon = new SearchAddon();
+ * term.loadAddon(searchAddon);
+ *
+ * searchAddon.findNext('hello');       // find and select next match
+ * searchAddon.findPrevious('hello');   // find and select previous match
+ * searchAddon.clearDecorations();      // clear search state
+ * ```
+ */
+
+import type { ITerminalAddon, ITerminalCore } from '../interfaces';
+import type { Terminal } from '../terminal';
+
+export interface ISearchOptions {
+  /** Use regex for matching (default: false) */
+  regex?: boolean;
+  /** Case-sensitive search (default: false) */
+  caseSensitive?: boolean;
+  /** Match whole word only (default: false) */
+  wholeWord?: boolean;
+  /** Search only in the current viewport (default: false — searches full buffer) */
+  incremental?: boolean;
+}
+
+interface SearchMatch {
+  /** Absolute buffer row (0 = top of scrollback) */
+  row: number;
+  /** Column where match starts */
+  col: number;
+  /** Length of the match in characters */
+  length: number;
+}
+
+export class SearchAddon implements ITerminalAddon {
+  private terminal?: Terminal;
+  private lastSearchTerm = '';
+  private lastSearchOptions: ISearchOptions = {};
+  private currentMatchIndex = -1;
+  private matches: SearchMatch[] = [];
+
+  activate(terminal: ITerminalCore): void {
+    this.terminal = terminal as Terminal;
+  }
+
+  dispose(): void {
+    this.clearDecorations();
+    this.terminal = undefined;
+  }
+
+  /**
+   * Find the next occurrence of a search term.
+   * @returns true if a match was found
+   */
+  findNext(term: string, options?: ISearchOptions): boolean {
+    if (!this.terminal || !term) return false;
+
+    // Re-search if term or options changed
+    if (term !== this.lastSearchTerm || !this.optionsMatch(options)) {
+      this.search(term, options);
+    }
+
+    if (this.matches.length === 0) return false;
+
+    // Advance to next match
+    this.currentMatchIndex = (this.currentMatchIndex + 1) % this.matches.length;
+    this.selectMatch(this.matches[this.currentMatchIndex]);
+    return true;
+  }
+
+  /**
+   * Find the previous occurrence of a search term.
+   * @returns true if a match was found
+   */
+  findPrevious(term: string, options?: ISearchOptions): boolean {
+    if (!this.terminal || !term) return false;
+
+    // Re-search if term or options changed
+    if (term !== this.lastSearchTerm || !this.optionsMatch(options)) {
+      this.search(term, options);
+    }
+
+    if (this.matches.length === 0) return false;
+
+    // Go to previous match
+    this.currentMatchIndex =
+      this.currentMatchIndex <= 0 ? this.matches.length - 1 : this.currentMatchIndex - 1;
+    this.selectMatch(this.matches[this.currentMatchIndex]);
+    return true;
+  }
+
+  /**
+   * Clear search state and selection.
+   */
+  clearDecorations(): void {
+    this.matches = [];
+    this.currentMatchIndex = -1;
+    this.lastSearchTerm = '';
+    this.lastSearchOptions = {};
+    this.terminal?.clearSelection();
+  }
+
+  /**
+   * Get total number of matches for the current search.
+   */
+  get matchCount(): number {
+    return this.matches.length;
+  }
+
+  /**
+   * Get the current match index (0-based), or -1 if no match.
+   */
+  get currentMatch(): number {
+    return this.currentMatchIndex;
+  }
+
+  // ==========================================================================
+  // Private
+  // ==========================================================================
+
+  private search(term: string, options?: ISearchOptions): void {
+    this.lastSearchTerm = term;
+    this.lastSearchOptions = options ?? {};
+    this.matches = [];
+    this.currentMatchIndex = -1;
+
+    const buf = this.terminal!.buffer.active;
+    const totalLines = buf.length;
+
+    let searchStr = term;
+    let regex: RegExp | null = null;
+
+    if (options?.regex) {
+      try {
+        regex = new RegExp(searchStr, options.caseSensitive ? 'g' : 'gi');
+      } catch {
+        return; // invalid regex
+      }
+    } else if (!options?.caseSensitive) {
+      searchStr = searchStr.toLowerCase();
+    }
+
+    for (let y = 0; y < totalLines; y++) {
+      const line = buf.getLine(y);
+      if (!line) continue;
+
+      const lineText = line.translateToString(false);
+
+      if (regex) {
+        // Regex search
+        regex.lastIndex = 0;
+        let match: RegExpExecArray | null = regex.exec(lineText);
+        while (match !== null) {
+          if (match[0].length === 0) {
+            regex.lastIndex++;
+          } else if (this.isWholeWord(lineText, match.index, match[0].length, options)) {
+            this.matches.push({ row: y, col: match.index, length: match[0].length });
+          }
+          match = regex.exec(lineText);
+        }
+      } else {
+        // Plain text search
+        const haystack = options?.caseSensitive ? lineText : lineText.toLowerCase();
+        let startIdx = 0;
+        while (startIdx < haystack.length) {
+          const idx = haystack.indexOf(searchStr, startIdx);
+          if (idx === -1) break;
+          if (this.isWholeWord(lineText, idx, searchStr.length, options)) {
+            this.matches.push({ row: y, col: idx, length: searchStr.length });
+          }
+          startIdx = idx + 1;
+        }
+      }
+    }
+  }
+
+  private isWholeWord(
+    text: string,
+    index: number,
+    length: number,
+    options?: ISearchOptions
+  ): boolean {
+    if (!options?.wholeWord) return true;
+
+    const before = index > 0 ? text[index - 1] : ' ';
+    const after = index + length < text.length ? text[index + length] : ' ';
+    return /\W/.test(before) && /\W/.test(after);
+  }
+
+  private selectMatch(match: SearchMatch): void {
+    const term = this.terminal!;
+    const buf = term.buffer.active;
+
+    // Calculate viewport scroll position to make match visible
+    const scrollbackLength = buf.length - term.rows;
+    if (scrollbackLength > 0 && match.row < scrollbackLength) {
+      // Match is in scrollback — scroll to it
+      const viewportY = scrollbackLength - match.row;
+      term.scrollToLine(match.row);
+    } else if (match.row >= scrollbackLength + term.rows) {
+      // Shouldn't happen, but safety
+      term.scrollToBottom();
+    }
+
+    // Select the match
+    term.select(match.col, match.row, match.length);
+  }
+
+  private optionsMatch(options?: ISearchOptions): boolean {
+    const a = this.lastSearchOptions;
+    const b = options ?? {};
+    return (
+      !!a.regex === !!b.regex &&
+      !!a.caseSensitive === !!b.caseSensitive &&
+      !!a.wholeWord === !!b.wholeWord
+    );
+  }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -95,6 +95,8 @@ export type { SelectionCoordinates } from './selection-manager';
 export { FitAddon } from './addons/fit';
 export type { ITerminalDimensions } from './addons/fit';
 export { WebglAddon } from './addons/webgl/webgl';
+export { SearchAddon } from './addons/search';
+export type { ISearchOptions } from './addons/search';
 
 // Link providers
 export { OSC8LinkProvider } from './providers/osc8-link-provider';


### PR DESCRIPTION
## Summary

The last P0 item. Adds `SearchAddon` for finding text in the terminal buffer (including scrollback).

```typescript
const search = new SearchAddon();
term.loadAddon(search);
search.findNext('error');        // find and highlight next match
search.findPrevious('error');    // find previous
search.clearDecorations();       // clear
```

### Features
- Case-insensitive (default) or case-sensitive search
- Regex search
- Whole-word matching
- Find next / find previous with wrap-around
- Auto-scroll to match in scrollback
- Highlights match via `term.select()`
- `matchCount` and `currentMatch` getters

## Test plan
- [x] 14 unit tests pass
- [x] typecheck, lint, fmt pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)