### PR TITLE
fix: make terminal free() idempotent and safe after grapheme lookups

### DIFF
--- a/lib/ghostty.ts
+++ b/lib/ghostty.ts
@@ -389,11 +389,11 @@ export class GhosttyTerminal {
   }
 
   free(): void {
-    if (this.viewportBufferPtr) {
-      this.exports.ghostty_wasm_free_u8_array(this.viewportBufferPtr, this.viewportBufferSize);
-      this.viewportBufferPtr = 0;
-    }
+    if (!this.handle) return;
+
+    this.invalidateBuffers();
     this.exports.ghostty_terminal_free(this.handle);
+    this.handle = 0 as TerminalHandle;
   }
 
   // ==========================================================================

--- a/lib/terminal.test.ts
+++ b/lib/terminal.test.ts
@@ -2845,6 +2845,20 @@ describe('Grapheme Cluster Support', () => {
 
     term.dispose();
   });
+
+  test('disposing after multi-codepoint grapheme lookups does not throw', async () => {
+    const term = await createIsolatedTerminal();
+    term.open(container!);
+
+    // Family emoji uses multiple codepoints joined into a single grapheme cluster.
+    term.write('👨‍👩‍👧‍👦');
+
+    const grapheme = term.wasmTerm!.getGraphemeString(0, 0);
+    expect(grapheme).toBe('👨‍👩‍👧‍👦');
+
+    expect(() => term.dispose()).not.toThrow();
+    expect(() => term.dispose()).not.toThrow();
+  });
 });
 
 // ==========================================================================


### PR DESCRIPTION
## Summary
- Refactors `GhosttyTerminal.free()` to call `invalidateBuffers()` for complete WASM buffer cleanup instead of only freeing the viewport buffer
- Zeros `this.handle` after freeing and adds early return guard, making `free()` idempotent and safe to call multiple times
- Adds test verifying terminal disposal doesn't throw after multi-codepoint grapheme cluster lookups (family emoji `👨‍👩‍👧‍👦`)

## Test plan
- [ ] Existing tests pass (`bun test`)
- [ ] New test `disposing after multi-codepoint grapheme lookups does not throw` passes
- [ ] Double `dispose()` call does not throw

🤖 Generated with [Claude Code](https://claude.com/claude-code)