### PR TITLE
fix: Shift+Enter sends nothing in legacy mode, wire kitty keyboard flags

### DIFF
--- a/lib/ghostty.ts
+++ b/lib/ghostty.ts
@@ -903,6 +903,21 @@ export class GhosttyTerminal {
     return this.exports.ghostty_terminal_get_mode(this.handle, mode, isAnsi) !== 0;
   }
 
+  /**
+   * Get the current kitty keyboard protocol flags.
+   * Returns 0 (DISABLED) if the WASM export is not available.
+   */
+  getKittyFlags(): number {
+    // The WASM binary may not have this export yet (requires rebuild with updated patch).
+    // Use a runtime check to gracefully fall back to legacy mode.
+    const fn = (this.exports as Record<string, unknown>)
+      .ghostty_terminal_get_kitty_keyboard_flags;
+    if (typeof fn !== 'function') {
+      return 0;
+    }
+    return (fn as (terminal: number) => number)(this.handle);
+  }
+
   // ==========================================================================
   // Private helpers
   // ==========================================================================

--- a/lib/input-handler.test.ts
+++ b/lib/input-handler.test.ts
@@ -570,6 +570,39 @@ describe('InputHandler', () => {
       expect(dataReceived[0]).toBe('\r');
     });
 
+    test('encodes Shift+Enter as carriage return', () => {
+      const handler = new InputHandler(
+        ghostty,
+        container as any,
+        (data) => dataReceived.push(data),
+        () => {
+          bellCalled = true;
+        }
+      );
+
+      simulateKey(container, createKeyEvent('Enter', 'Enter', { shift: true }));
+
+      expect(dataReceived.length).toBe(1);
+      // Shift+Enter should produce \r in legacy mode (same as Enter)
+      expect(dataReceived[0]).toBe('\r');
+    });
+
+    test('Shift+Enter calls preventDefault', () => {
+      const handler = new InputHandler(
+        ghostty,
+        container as any,
+        (data) => dataReceived.push(data),
+        () => {
+          bellCalled = true;
+        }
+      );
+
+      const event = createKeyEvent('Enter', 'Enter', { shift: true });
+      simulateKey(container, event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+
     test('encodes Tab', () => {
       const handler = new InputHandler(
         ghostty,
@@ -925,6 +958,27 @@ describe('InputHandler', () => {
       simulateKey(container, event);
 
       expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    test('does not preventDefault when encoder produces empty output', () => {
+      const handler = new InputHandler(
+        ghostty,
+        container as any,
+        (data) => dataReceived.push(data),
+        () => {
+          bellCalled = true;
+        }
+      );
+
+      // Use a modifier combo that bypasses the fast-path (Ctrl+Shift)
+      // and may produce empty encoder output for a key without a legacy encoding
+      const event = createKeyEvent('Enter', 'Enter', { ctrl: true, shift: true });
+      simulateKey(container, event);
+
+      // If no data was produced, preventDefault should not have been called
+      if (dataReceived.length === 0) {
+        expect(event.preventDefault).not.toHaveBeenCalled();
+      }
     });
   });
 

--- a/lib/input-handler.ts
+++ b/lib/input-handler.ts
@@ -219,10 +219,10 @@ export class InputHandler {
    * @param onKey - Optional callback for raw key events
    * @param customKeyEventHandler - Optional custom key event handler
    * @param getMode - Optional callback to query terminal mode state (for application cursor mode)
-   * @param getKittyFlags - Optional callback to query kitty keyboard protocol flags
    * @param onCopy - Optional callback to handle copy (Cmd+C/Ctrl+C with selection)
    * @param inputElement - Optional input element for beforeinput events
    * @param mouseConfig - Optional mouse tracking configuration
+   * @param getKittyFlags - Optional callback to query kitty keyboard protocol flags
    */
   constructor(
     ghostty: Ghostty,
@@ -232,10 +232,10 @@ export class InputHandler {
     onKey?: (keyEvent: IKeyEvent) => void,
     customKeyEventHandler?: (event: KeyboardEvent) => boolean,
     getMode?: (mode: number) => boolean,
-    getKittyFlags?: () => number,
     onCopy?: () => boolean,
     inputElement?: HTMLElement,
-    mouseConfig?: MouseTrackingConfig
+    mouseConfig?: MouseTrackingConfig,
+    getKittyFlags?: () => number
   ) {
     this.encoder = ghostty.createKeyEncoder();
     this.container = container;

--- a/lib/input-handler.ts
+++ b/lib/input-handler.ts
@@ -181,6 +181,7 @@ export class InputHandler {
   private onKeyCallback?: (keyEvent: IKeyEvent) => void;
   private customKeyEventHandler?: (event: KeyboardEvent) => boolean;
   private getModeCallback?: (mode: number) => boolean;
+  private getKittyFlagsCallback?: () => number;
   private onCopyCallback?: () => boolean;
   private mouseConfig?: MouseTrackingConfig;
   private keydownListener: ((e: KeyboardEvent) => void) | null = null;
@@ -218,6 +219,7 @@ export class InputHandler {
    * @param onKey - Optional callback for raw key events
    * @param customKeyEventHandler - Optional custom key event handler
    * @param getMode - Optional callback to query terminal mode state (for application cursor mode)
+   * @param getKittyFlags - Optional callback to query kitty keyboard protocol flags
    * @param onCopy - Optional callback to handle copy (Cmd+C/Ctrl+C with selection)
    * @param inputElement - Optional input element for beforeinput events
    * @param mouseConfig - Optional mouse tracking configuration
@@ -230,6 +232,7 @@ export class InputHandler {
     onKey?: (keyEvent: IKeyEvent) => void,
     customKeyEventHandler?: (event: KeyboardEvent) => boolean,
     getMode?: (mode: number) => boolean,
+    getKittyFlags?: () => number,
     onCopy?: () => boolean,
     inputElement?: HTMLElement,
     mouseConfig?: MouseTrackingConfig
@@ -242,6 +245,7 @@ export class InputHandler {
     this.onKeyCallback = onKey;
     this.customKeyEventHandler = customKeyEventHandler;
     this.getModeCallback = getMode;
+    this.getKittyFlagsCallback = getKittyFlags;
     this.onCopyCallback = onCopy;
     this.mouseConfig = mouseConfig;
 
@@ -433,15 +437,17 @@ export class InputHandler {
     // Extract modifiers
     const mods = this.extractModifiers(event);
 
+    // When kitty keyboard protocol is active, skip the fast-path and let
+    // the encoder handle all keys (e.g. Shift+Enter → CSI 13;2u).
+    const kittyActive = this.getKittyFlagsCallback ? this.getKittyFlagsCallback() > 0 : false;
+
     // Handle simple special keys that produce standard sequences
-    if (mods === Mods.NONE || mods === Mods.SHIFT) {
+    if (!kittyActive && (mods === Mods.NONE || mods === Mods.SHIFT)) {
       let simpleOutput: string | null = null;
 
       switch (key) {
         case Key.ENTER:
-          if (mods === Mods.NONE) {
-            simpleOutput = '\r'; // Carriage return (Shift+Enter goes to encoder for CSI u)
-          }
+          simpleOutput = '\r'; // Carriage return
           break;
         case Key.TAB:
           if (mods === Mods.SHIFT) {
@@ -535,6 +541,11 @@ export class InputHandler {
         this.encoder.setOption(KeyEncoderOption.CURSOR_KEY_APPLICATION, appCursorMode);
       }
 
+      // Sync kitty keyboard flags from the terminal
+      if (this.getKittyFlagsCallback) {
+        this.encoder.setKittyFlags(this.getKittyFlagsCallback());
+      }
+
       // For letter/number keys, even with modifiers, pass the base character
       // This helps the encoder produce correct control sequences (e.g., Ctrl+A = 0x01)
       // For special keys (Enter, Arrow keys, etc.), don't pass utf8
@@ -554,12 +565,12 @@ export class InputHandler {
       const decoder = new TextDecoder();
       const data = decoder.decode(encoded);
 
-      // Prevent default browser behavior
-      event.preventDefault();
-      event.stopPropagation();
-
-      // Emit the data
+      // Only prevent default and emit if the encoder produced output.
+      // When the encoder returns empty, let the event propagate so the
+      // beforeinput handler can serve as a fallback (e.g. insertLineBreak).
       if (data.length > 0) {
+        event.preventDefault();
+        event.stopPropagation();
         this.onDataCallback(data);
         this.recordKeyDownData(data);
       }

--- a/lib/terminal.ts
+++ b/lib/terminal.ts
@@ -632,6 +632,10 @@ export class Terminal implements ITerminalCore {
           return this.wasmTerm?.getMode(mode, false) ?? false;
         },
         () => {
+          // Query kitty keyboard protocol flags (0 = legacy mode)
+          return this.wasmTerm?.getKittyFlags() ?? 0;
+        },
+        () => {
           // Handle Cmd+C copy - returns true if there was a selection to copy
           return this.copySelection();
         },

--- a/lib/terminal.ts
+++ b/lib/terminal.ts
@@ -632,15 +632,15 @@ export class Terminal implements ITerminalCore {
           return this.wasmTerm?.getMode(mode, false) ?? false;
         },
         () => {
-          // Query kitty keyboard protocol flags (0 = legacy mode)
-          return this.wasmTerm?.getKittyFlags() ?? 0;
-        },
-        () => {
           // Handle Cmd+C copy - returns true if there was a selection to copy
           return this.copySelection();
         },
         this.textarea,
-        mouseConfig
+        mouseConfig,
+        () => {
+          // Query kitty keyboard protocol flags (0 = legacy mode)
+          return this.wasmTerm?.getKittyFlags() ?? 0;
+        }
       );
 
       // Apply macOptionIsMeta if set

--- a/patches/ghostty-wasm-api.patch
+++ b/patches/ghostty-wasm-api.patch
@@ -234,6 +234,12 @@ index 000000000..c467102c3
 + */
 +bool ghostty_terminal_get_mode(GhosttyTerminal term, int mode, bool is_ansi);
 +
++/**
++ * Get the current kitty keyboard protocol flags.
++ * @return Bitfield of active kitty keyboard flags (0 = disabled/legacy mode)
++ */
++int ghostty_terminal_get_kitty_keyboard_flags(GhosttyTerminal term);
++
 +/* ============================================================================
 + * Scrollback API
 + * ========================================================================= */
@@ -374,6 +380,7 @@ index 03a883e20..1336676d7 100644
 +        @export(&c.terminal_is_alternate_screen, .{ .name = "ghostty_terminal_is_alternate_screen" });
 +        @export(&c.terminal_has_mouse_tracking, .{ .name = "ghostty_terminal_has_mouse_tracking" });
 +        @export(&c.terminal_get_mode, .{ .name = "ghostty_terminal_get_mode" });
++        @export(&c.terminal_get_kitty_keyboard_flags, .{ .name = "ghostty_terminal_get_kitty_keyboard_flags" });
 +
 +        // Scrollback API
 +        @export(&c.terminal_get_scrollback_length, .{ .name = "ghostty_terminal_get_scrollback_length" });
@@ -436,6 +443,7 @@ index bc92597f5..d0ee49c1b 100644
 +pub const terminal_is_alternate_screen = terminal.isAlternateScreen;
 +pub const terminal_has_mouse_tracking = terminal.hasMouseTracking;
 +pub const terminal_get_mode = terminal.getMode;
++pub const terminal_get_kitty_keyboard_flags = terminal.getKittyKeyboardFlags;
 +
 +// Scrollback API
 +pub const terminal_get_scrollback_length = terminal.getScrollbackLength;
@@ -1350,6 +1358,13 @@ index 000000000..73ae2e6fa
 +    const wrapper: *const TerminalWrapper = @ptrCast(@alignCast(ptr orelse return false));
 +    const mode = modespkg.modeFromInt(@intCast(mode_num), is_ansi) orelse return false;
 +    return wrapper.terminal.modes.get(mode);
++}
++
++/// Get the current kitty keyboard protocol flags
++/// Returns the raw flags value from the kitty keyboard stack (0 = disabled)
++pub fn getKittyKeyboardFlags(ptr: ?*anyopaque) callconv(.c) c_int {
++    const wrapper: *const TerminalWrapper = @ptrCast(@alignCast(ptr orelse return 0));
++    return @intCast(wrapper.terminal.screens.active.kitty_keyboard.current());
 +}
 +
 +// ============================================================================


### PR DESCRIPTION
Shift+Enter was silently swallowed because the fast-path only handled
plain Enter (mods === NONE) and the encoder fallback called
preventDefault() unconditionally even when returning empty output,
killing the beforeinput fallback.

Three fixes:
- Handle Shift+Enter in the fast-path, producing \r like plain Enter
- Only call preventDefault/stopPropagation when the encoder produces
  non-empty output, letting the beforeinput handler serve as fallback
- Wire kitty keyboard protocol flags from GhosttyTerminal through to
  KeyEncoder.setKittyFlags(), with graceful fallback when the WASM
  export is not yet available (patch included for next WASM rebuild)

When kitty mode is active, the fast-path is skipped so the encoder
can produce proper CSI u sequences (e.g. Shift+Enter → CSI 13;2u).

Closes #15

https://claude.ai/code/session_01BQRxbHqszZ7EmhSRvvaf5X